### PR TITLE
Make readRegister and writeRegister public so error checking is possible

### DIFF
--- a/src/INA219_WE.h
+++ b/src/INA219_WE.h
@@ -112,6 +112,8 @@ private:
     float currentDivider_mA;
     float pwrMultiplier_mW;
     bool calc_overflow;
+
+public:
     byte writeRegister(uint8_t reg, uint16_t val);
     uint16_t readRegister(uint8_t reg);
 


### PR DESCRIPTION
I find it useful to use readRegister to check if the device was initialized properly, since otherwise some errors can sneak by undetected.