### PR TITLE
Remove unnecessary register read for triggered measurement & new function getConversionReady

### DIFF
--- a/src/INA219_WE.cpp
+++ b/src/INA219_WE.cpp
@@ -174,8 +174,7 @@ bool INA219_WE::getOverflow(){
 }
 
 void INA219_WE::startSingleMeasurement(){
-    uint16_t val = readRegister(INA219_BUS_REG); // clears CNVR (Conversion Ready) Flag
-    val = readRegister(INA219_CONF_REG);
+    uint16_t val = readRegister(INA219_CONF_REG);
     writeRegister(INA219_CONF_REG, val);
     uint16_t convReady = 0x0000;
     while(!convReady){
@@ -185,8 +184,7 @@ void INA219_WE::startSingleMeasurement(){
 
 
 bool INA219_WE::startSingleMeasurement(unsigned long timeout_us){
-    uint16_t val = readRegister(INA219_BUS_REG); // clears CNVR (Conversion Ready) Flag
-    val = readRegister(INA219_CONF_REG);
+    uint16_t val = readRegister(INA219_CONF_REG);
     writeRegister(INA219_CONF_REG, val);
     uint16_t convReady = 0x0000;
     unsigned long convStart = micros();

--- a/src/INA219_WE.cpp
+++ b/src/INA219_WE.cpp
@@ -174,7 +174,11 @@ bool INA219_WE::getOverflow(){
 }
 
 bool INA219_WE::getConversionReady(){
-	return readRegister(INA219_BUS_REG) & 0x0002;
+	if(readRegister(INA219_BUS_REG) & 0x0002){
+		readRegister(INA219_PWR_REG); //Reset the CNVR flag!
+		return true;
+	}
+	return false;
 }
 
 void INA219_WE::startSingleMeasurement(){

--- a/src/INA219_WE.cpp
+++ b/src/INA219_WE.cpp
@@ -173,6 +173,10 @@ bool INA219_WE::getOverflow(){
     return overflow;
 }
 
+bool INA219_WE::getConversionReady(){
+	return readRegister(INA219_BUS_REG) & 0x0002;
+}
+
 void INA219_WE::startSingleMeasurement(){
     uint16_t val = readRegister(INA219_CONF_REG);
     writeRegister(INA219_CONF_REG, val);

--- a/src/INA219_WE.h
+++ b/src/INA219_WE.h
@@ -104,7 +104,7 @@ class INA219_WE
         float getCurrent_mA();
         float getBusPower();
         bool getOverflow();
-		bool getConversionReady(); //Note: ConversionReady only gets reset if getBusPower is called (or the Configuration Register is written somehow)!
+	bool getConversionReady();
         void startSingleMeasurement();
         bool startSingleMeasurement(unsigned long timeout_us);
         void powerDown();

--- a/src/INA219_WE.h
+++ b/src/INA219_WE.h
@@ -104,6 +104,7 @@ class INA219_WE
         float getCurrent_mA();
         float getBusPower();
         bool getOverflow();
+		bool getConversionReady(); //Note: ConversionReady only gets reset if getBusPower is called (or the Configuration Register is written somehow)!
         void startSingleMeasurement();
         bool startSingleMeasurement(unsigned long timeout_us);
         void powerDown();


### PR DESCRIPTION
According to the datasheet reading the INA219_BUS_REG does not clear the CNVR flag. Reading the INA219_PWR_REG instead would clear the CNVR flag. Since the INA219_CONF_REG is written afterwards anyways, even a read of the INA219_PWR_REG would be unnecessary. Checked the behaviour with the Triggerd example and everything seems to be fine.

Also I added the function getConversionReady. I need this function for my personal project to know when new values are available in continuous mode to then act accordingly. I think other people could benefit from it aswell. I reset the CNVR flag by calling readRegister(INA219_PWR_REG).

Thank you for your efforts!